### PR TITLE
Add hypre to nvchecker.toml

### DIFF
--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -18,6 +18,11 @@ source = "regex"
 regex = 'RELEASE NOTES FOR HEASOFT ([\d.]+)'
 url = "https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/release_notes.html"
 
+[hypre]
+source = "github"
+github = "hypre-space/hypre"
+use_max_tag = true
+
 [jgit]
 source = "regex"
 regex = 'Direct Download ([\d.]+.*)</h2>'


### PR DESCRIPTION
Using for this case `use_max_tag = true` because not always hypre make a new GitHub release, but always a new tag.