### PR TITLE
Add KaHIP

### DIFF
--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -23,6 +23,11 @@ source = "regex"
 regex = 'Direct Download ([\d.]+.*)</h2>'
 url = "http://www.eclipse.org/jgit/download/"
 
+[kahip]
+source = "github"
+github = "KaHIP/KaHIP"
+use_latest_release = true
+
 [openfoam]
 source = "github"
 github = "OpenFOAM/OpenFOAM-10"


### PR DESCRIPTION
In the future, `openfoam-com` could be needed it again.