### PR TITLE
Add python-multiprocess

### DIFF
--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -43,6 +43,11 @@ source = "github"
 github = "librosa/librosa"
 use_latest_release = true
 
+[python-multiprocess]
+source = "github"
+github = "uqfoundation/multiprocess"
+use_latest_release = true
+
 [python-numpy-mkl]
 source = "github"
 github = "numpy/numpy"


### PR DESCRIPTION
Add a tracker for `python-multiprocess` from AUR. Lately not packaged by arch4edu.