### PR TITLE
Add python-pydotplus

### DIFF
--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -78,6 +78,10 @@ source = "github"
 github = "IntelPython/mkl_random"
 use_latest_release = true
 
+[python-pydotplus]
+source = "pypi"
+pypi = "pydotplus"
+
 [python-pydub]
 source = "github"
 github = "jiaaro/pydub"


### PR DESCRIPTION
Add a tracker from pypi because the github repository does not push tags for `python-pydotplus` (old package from 2014) from AUR.