### PR TITLE
Add libxc

### DIFF
--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -38,6 +38,11 @@ source = "github"
 github = "KaHIP/KaHIP"
 use_latest_release = true
 
+[libxc]
+source = "gitlab"
+gitlab = "libxc/libxc"
+use_max_tag = true
+
 [openfoam]
 source = "github"
 github = "OpenFOAM/OpenFOAM-10"


### PR DESCRIPTION
This pull request is enabling watching new versions from gitlab https://gitlab.com/libxc/libxc/-/tags, other way could be using regex from https://www.tddft.org/programs/libxc/download