### PR TITLE
Capitalize AUR commit message

### DIFF
--- a/update-scripts/default.sh
+++ b/update-scripts/default.sh
@@ -18,5 +18,5 @@ sed "s/^pkgrel=.*$/pkgrel=1/" -i PKGBUILD
 su makepkg -c 'updpkgsums'
 su makepkg -c 'makepkg --printsrcinfo' > .SRCINFO
 git add PKGBUILD .SRCINFO
-git commit -m "auto updated to ${newver}"
+git commit -m "Auto updated to ${newver}"
 git push origin master


### PR DESCRIPTION
In the AUR, package maintainers usually capitalize the commit message, so maybe we could do the same