### PR TITLE
Zapzap upstream moved to `zapzap-linux/zapzap`

### DIFF
--- a/config/bordam/zapzap.yaml
+++ b/config/bordam/zapzap.yaml
@@ -1,5 +1,5 @@
 nvchecker:
-  github: rafatosta/zapzap
+  github: zapzap-linux/zapzap
   source: github
   use_latest_release: true
   prefix: v


### PR DESCRIPTION
`zapzap` repo is now at https://github.com/zapzap-linux/zapzap