### PR TITLE
Add `zapzap-git`

### DIFF
--- a/config/alllexx88/zapzap-git.override
+++ b/config/alllexx88/zapzap-git.override
@@ -1,0 +1,13 @@
+#!/bin/sh
+newver="$1" #Just input whatever nvchecker returns, it'll be never used.
+force="$2"
+
+if [ -z "${force}" ]; then
+  oldver=$(grep -P '^pkgver=' PKGBUILD | cut -d= -f2)
+  su makepkg -c 'makepkg -od --noprepare'
+  newver=$(grep -P '^pkgver=' PKGBUILD | cut -d= -f2)
+  [ $(vercmp "${oldver}" "${newver}") -eq 1 ] && echo "The oldver ${oldver} is greater than newver ${newver}." && exit 1
+  if [ "${oldver}" != "${newver}" ]; then
+    sed "s/^pkgrel=.*$/pkgrel=1/" -i PKGBUILD
+  fi
+fi

--- a/config/alllexx88/zapzap-git.yaml
+++ b/config/alllexx88/zapzap-git.yaml
@@ -1,4 +1,4 @@
 nvchecker:
-  source: cmd
-  cmd: bash -c 'dir=$(mktemp -d -t zapzap-git-XXXXXX); (cd $dir && git clone https://github.com/zapzap-linux/zapzap && cd zapzap && git describe --long --tags | sed "s/^foo-//;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//"); rm -rf $dir'
+  source: github
+  github: zapzap-linux/zapzap
 test: true

--- a/config/alllexx88/zapzap-git.yaml
+++ b/config/alllexx88/zapzap-git.yaml
@@ -1,0 +1,4 @@
+nvchecker:
+  source: cmd
+  cmd: bash -c 'dir=$(mktemp -d -t zapzap-git-XXXXXX); (cd $dir && git clone https://github.com/zapzap-linux/zapzap && cd zapzap && git describe --long --tags | sed "s/^foo-//;s/\([^-]*-g\)/r\1/;s/-/./g;s/^v//"); rm -rf $dir'
+test: true


### PR DESCRIPTION
I haven't found any examples of using `nvchecker` with `-git` AUR packages, so I'm not sure if that's the best solution, but this is the easiest way I could think of: cloning to a temp dir, using `git describe` and removing the dir.

I first tried a different approach, using github API, with this script (it's not difficult to convert it to a one-liner, a *long* one :sweat_smile: ):

```bash
#!/bin/bash

repo=zapzap-linux/zapzap

tag=$(curl -s "https://api.github.com/repos/$repo/releases/latest" | jq -r '.tag_name')
read type tag_sha < <(echo $(curl -s "https://api.github.com/repos/$repo/git/ref/tags/$tag" |
     jq -r '.object.type,.object.sha'))

if [ $type == "commit" ]; then
    from_sha=$tag_sha
else
    from_sha=$(curl -s "https://api.github.com/repos/$repo/git/tags/$tag_sha" | jq '.object.sha')
fi

commit_history=$(curl -s "https://api.github.com/repos/$repo/commits?sha=main&per_page=100" | jq '.[].sha')

i=1
while ! echo "$commit_history" | grep -qFx $from_sha; do
    i=$(( $i + 1))
    new_commits=$(curl -s "https://api.github.com/repos/$repo/commits?sha=main&per_page=100&page=$i" | jq '.[].sha')
    commit_history=$(echo $commit_history $new_commits | sed -e 's/ /\n/g')
    if [ -z "$new_commits" ]; then
        break
    fi
done

commits_since_release=$(( $(echo "$commit_history" | sed -n "0,/$from_sha/p" | wc -l) - 1 ))

head_sha=$(echo "$commit_history" | head -1 | tr -d '"')

echo ${tag}.r$commits_since_release.g${head_sha:0:7}
```
But I believe it's more issues prone and is unreadable as a one-liner:
```yaml
nvchecker:
  source: cmd
  cmd: bash -c 'repo=zapzap-linux/zapzap; tag=$(curl -s "https://api.github.com/repos/$repo/releases/latest" | jq -r ".tag_name"); read type tag_sha < <(echo $(curl -s "https://api.github.com/repos/$repo/git/ref/tags/$tag" | jq -r ".object.type,.object.sha")); if [ $type == "commit" ]; then from_sha=$tag_sha; else from_sha=$(curl -s "https://api.github.com/repos/$repo/git/tags/$tag_sha" | jq ".object.sha"); fi; commit_history=$(curl -s "https://api.github.com/repos/$repo/commits?sha=main&per_page=20" | jq ".[].sha"); i=1; while ! echo "$commit_history" | grep -qFx $from_sha; do i=$(( $i + 1)); new_commits=$(curl -s "https://api.github.com/repos/$repo/commits?sha=main&per_page=20&page=$i" | jq ".[].sha"); commit_history=$(echo $commit_history $new_commits | sed -e "s/ /\n/g"); if [ -z "$new_commits" ]; then break; fi; done; commits_since_release=$(( $(echo "$commit_history" | sed -n "0,/$from_sha/p" | wc -l) - 1 )); head_sha=$(echo "$commit_history" | head -1 | tr -d "\""); echo ${tag}.r$commits_since_release.g${head_sha:0:7}'
test: true
```
It also quickly reaches rate limits for the github REST API when used few times in a row.

Thanks