### PR TITLE
Rename whatsapp-for-linux → wasistlos

### DIFF
--- a/config/bordam/wasistlos.yaml
+++ b/config/bordam/wasistlos.yaml
@@ -1,5 +1,5 @@
 nvchecker:
-  github: eneshecan/whatsapp-for-linux
+  github: xeco23/WasIstLos
   source: github
   use_latest_release: true
   prefix: v


### PR DESCRIPTION
This reflects the upstream rename to WasIstLos.